### PR TITLE
Enhance vendor response flow

### DIFF
--- a/src/context/DataContext.js
+++ b/src/context/DataContext.js
@@ -773,6 +773,7 @@ export const DataProvider = ({ children }) => {
       dateTime: new Date().toISOString(),
       status: 'New',
       vendorId: null, // will be set when assigned
+      vendorResponseStatus: null,
       notes: notes ? [{text: notes, date: new Date().toISOString(), by: placedBy}] : [],
       mediaUrls,
       priority,
@@ -866,6 +867,7 @@ const assignTicket = (id, vendorId) => {
     vendorId,
     status: 'Assigned',
     currentStep: 'waiting_vendor_response',
+    vendorResponseStatus: null,
     workOrders: [
       ...(ticket.workOrders || []),
       {
@@ -888,11 +890,12 @@ const assignTicket = (id, vendorId) => {
     if (!ticket) return false;
     
     // Update ticket with vendor acceptance
-    updateTicket(id, {
-      ...ticket,
-      status: 'In Progress',
-      currentStep: 'vendor_accepted',
-      workOrders: [
+  updateTicket(id, {
+    ...ticket,
+    status: 'In Progress',
+    currentStep: 'vendor_accepted',
+    vendorResponseStatus: 'accepted',
+    workOrders: [
         ...(ticket.workOrders || []),
         {
           type: 'vendor_accepted',
@@ -913,11 +916,12 @@ const assignTicket = (id, vendorId) => {
     if (!ticket) return false;
     
     // Update ticket with vendor rejection
-    updateTicket(id, {
-      ...ticket,
-      status: 'Rejected',
-      currentStep: 'vendor_rejected',
-      workOrders: [
+  updateTicket(id, {
+    ...ticket,
+    status: 'Rejected',
+    currentStep: 'vendor_rejected',
+    vendorResponseStatus: 'rejected',
+    workOrders: [
         ...(ticket.workOrders || []),
         {
           type: 'vendor_rejected',
@@ -938,11 +942,12 @@ const assignTicket = (id, vendorId) => {
     if (!ticket) return false;
     
     // Update ticket with info request
-    updateTicket(id, {
-      ...ticket,
-      status: 'More Info Needed',
-      currentStep: 'more_info_requested',
-      workOrders: [
+  updateTicket(id, {
+    ...ticket,
+    status: 'More Info Needed',
+    currentStep: 'more_info_requested',
+    vendorResponseStatus: 'more_info_requested',
+    workOrders: [
         ...(ticket.workOrders || []),
         {
           type: 'more_info_requested',
@@ -963,11 +968,12 @@ const assignTicket = (id, vendorId) => {
     if (!ticket) return false;
     
     // Update ticket with additional info
-    updateTicket(id, {
-      ...ticket,
-      status: 'Assigned',
-      currentStep: 'waiting_vendor_response',
-      workOrders: [
+  updateTicket(id, {
+    ...ticket,
+    status: 'Assigned',
+    currentStep: 'waiting_vendor_response',
+    vendorResponseStatus: null,
+    workOrders: [
         ...(ticket.workOrders || []),
         {
           type: 'more_info_provided',

--- a/src/models/Ticket.js
+++ b/src/models/Ticket.js
@@ -37,6 +37,11 @@ const TicketSchema = new mongoose.Schema({
     default: 'New'
   },
   vendorId: String,
+  vendorResponseStatus: {
+    type: String,
+    enum: ['accepted', 'rejected', 'more_info_requested', null],
+    default: null
+  },
   notes: [NoteSchema],
   mediaUrls: [String],
   adminApproved: {

--- a/src/pages/VendorOrganizationDetail.js
+++ b/src/pages/VendorOrganizationDetail.js
@@ -329,6 +329,12 @@ const VendorOrganizationDetail = () => {
     return date.toLocaleString();
   };
 
+  const responseButtonLabel =
+    responseType === 'accept' ? 'Accept Ticket' :
+    responseType === 'reject' ? 'Reject Ticket' :
+    responseType === 'moreInfo' ? 'Request Info' :
+    'Submit';
+
   return (
     <Box>
       {/* Header */}
@@ -444,42 +450,42 @@ const VendorOrganizationDetail = () => {
                         {/* Only show action buttons for tickets that need vendor response */}
                         {(ticket.status === 'New' || ticket.status === 'Assigned') && !ticket.vendorResponseStatus ? (
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <Tooltip title="Accept ticket">
-                              <IconButton 
-                                color="success" 
-                                size="small"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleOpenResponseDialog(ticket.id, 'accept');
-                                }}
-                              >
-                                <AcceptIcon />
-                              </IconButton>
-                            </Tooltip>
-                            <Tooltip title="Reject ticket">
-                              <IconButton 
-                                color="error" 
-                                size="small"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleOpenResponseDialog(ticket.id, 'reject');
-                                }}
-                              >
-                                <RejectIcon />
-                              </IconButton>
-                            </Tooltip>
-                            <Tooltip title="Request more information">
-                              <IconButton 
-                                color="info" 
-                                size="small"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleOpenResponseDialog(ticket.id, 'moreInfo');
-                                }}
-                              >
-                                <RequestInfoIcon />
-                              </IconButton>
-                            </Tooltip>
+                            <Button
+                              variant="outlined"
+                              color="success"
+                              size="small"
+                              startIcon={<AcceptIcon />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleOpenResponseDialog(ticket.id, 'accept');
+                              }}
+                            >
+                              Accept
+                            </Button>
+                            <Button
+                              variant="outlined"
+                              color="error"
+                              size="small"
+                              startIcon={<RejectIcon />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleOpenResponseDialog(ticket.id, 'reject');
+                              }}
+                            >
+                              Reject
+                            </Button>
+                            <Button
+                              variant="outlined"
+                              color="info"
+                              size="small"
+                              startIcon={<RequestInfoIcon />}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleOpenResponseDialog(ticket.id, 'moreInfo');
+                              }}
+                            >
+                              More Info
+                            </Button>
                           </Box>
                         ) : (
                           <Button 
@@ -713,13 +719,13 @@ const VendorOrganizationDetail = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseResponseDialog}>Cancel</Button>
-          <Button 
-            onClick={handleResponseSubmit} 
+          <Button
+            onClick={handleResponseSubmit}
             variant="contained"
             color={responseType === 'accept' ? 'success' : responseType === 'reject' ? 'error' : 'primary'}
-            disabled={(responseType !== 'accept' && !responseNote)}
+            disabled={responseType !== 'accept' && !responseNote}
           >
-            Submit
+            {responseButtonLabel}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## Summary
- clarify vendor response dialog label
- switch vendor action icons to labeled buttons
- track `vendorResponseStatus` in tickets
- expose accept/reject buttons from ticket detail page

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d08cb3da0832993683fa79c4de140